### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/hsaito/VE_Count_Consolidator/security/code-scanning/1](https://github.com/hsaito/VE_Count_Consolidator/security/code-scanning/1)

To fix the problem, explicitly declare restricted `GITHUB_TOKEN` permissions for the workflow or the specific job. Since this workflow only checks out code and runs `dotnet restore/build/test`, it only requires read access to repository contents. The least-privilege fix is to add `permissions: contents: read` at the workflow level (top-level key), which applies to all jobs and avoids changing existing behavior for this build job.

Concretely, edit `.github/workflows/dotnet.yml` and insert a `permissions:` block near the top, alongside `name:` and `on:`. For example, after line 5 (`name: .NET`), add:

```yaml
permissions:
  contents: read
```

No other steps, actions, or imports are required. This will ensure that `GITHUB_TOKEN` is limited to read-only contents access for this workflow, satisfying CodeQL’s recommendation while preserving all current functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
